### PR TITLE
Connected Settings to Main

### DIFF
--- a/src/components/GeneralData.jsx
+++ b/src/components/GeneralData.jsx
@@ -12,7 +12,14 @@ class GeneralData extends Component {
   };
 
   render() {
-    const { classes, currentWeather, forecastWeather, isLoaded } = this.props;
+    const {
+      classes,
+      currentWeather,
+      forecastWeather,
+      isLoaded,
+      temperatureUnit,
+      windSpeedUnit,
+    } = this.props;
     const { sliderValue } = this.state;
     return (
       <>

--- a/src/components/GeneralData.jsx
+++ b/src/components/GeneralData.jsx
@@ -9,6 +9,7 @@ class GeneralData extends Component {
 
   handleChange = (event, sliderValue) => {
     this.setState({ sliderValue });
+    this.props.onChangeSliderValue(sliderValue);
   };
 
   render() {
@@ -19,6 +20,7 @@ class GeneralData extends Component {
       isLoaded,
       temperatureUnit,
       windSpeedUnit,
+      onChangeSliderValue
     } = this.props;
     const { sliderValue } = this.state;
     return (
@@ -40,24 +42,38 @@ class GeneralData extends Component {
           />
         </div>
         <h1 className={classes.container}>
-          {sliderValue === 0
-            ? isLoaded && currentWeather.windKPH + " KPH"
-            : isLoaded &&
-              forecastWeather[sliderValue - 1].windSpeedKPH + " KPH"}
+          {isLoaded &&
+            this.getWindSpeedDataBasedOnUnit(sliderValue, windSpeedUnit)}
         </h1>
         <h1 className={classes.container}>
-          {sliderValue === 0
-            ? isLoaded && currentWeather.tempC + " °C"
-            : isLoaded && forecastWeather[sliderValue - 1].tempC + " °C"}
+          {isLoaded &&
+            this.getTemperatureDataBasedOnUnit(sliderValue, temperatureUnit)}
         </h1>
         <h1 className={classes.container}>
-          {sliderValue === 0
-            ? isLoaded && currentWeather.weatherShort
-            : isLoaded && forecastWeather[Math.floor(sliderValue) - 1].weather}
+          {isLoaded && forecastWeather[sliderValue].weather}
         </h1>
       </>
     );
   }
+
+  getWindSpeedDataBasedOnUnit = (sliderValue, unit) => {
+    const { forecastWeather } = this.props;
+    switch (unit) {
+      case "KPH":
+        return `${forecastWeather[sliderValue].windSpeedKPH} ${unit}`;
+      case "MPH":
+        return `${forecastWeather[sliderValue].windSpeedMPH} ${unit}`;
+      case "KTS":
+        return `${forecastWeather[sliderValue].windSpeedKTS} ${unit}`;
+    }
+  };
+
+  getTemperatureDataBasedOnUnit = (sliderValue, unit) => {
+    const { forecastWeather } = this.props;
+    return unit === "F"
+      ? `${forecastWeather[sliderValue].tempF} °F`
+      : `${forecastWeather[sliderValue].tempC} °C`;
+  };
 }
 
 const styles = createStyles({

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -25,7 +25,12 @@ class Main extends Component {
     forecastWeather: "",
     // Indicates if we received the API data correctly
     isLoaded: false,
-    isSettingsMenuOpen: false
+    isSettingsMenuOpen: false,
+    // Default settings. User can change these in the Settings
+    temperatureUnit: "C",
+    windSpeedUnit: "KPH",
+    minimumTemperature: 20,
+    minimumWindSpeed: 15,
   };
 
   render() {
@@ -34,7 +39,11 @@ class Main extends Component {
       currentWeather,
       forecastWeather,
       isLoaded,
-      isSettingsMenuOpen
+      isSettingsMenuOpen,
+      temperatureUnit,
+      windSpeedUnit,
+      minimumWindSpeed,
+      minimumTemperature
     } = this.state;
 
     return (
@@ -50,9 +59,20 @@ class Main extends Component {
             isLoaded={isLoaded}
             currentWeather={currentWeather}
             forecastWeather={forecastWeather}
+            temperatureUnit={temperatureUnit}
+            windSpeedUnit={windSpeedUnit}
           />
         ) : (
-          <Settings />
+          <Settings
+            temperatureUnit={temperatureUnit}
+            windSpeedUnit={windSpeedUnit}
+            minimumWindSpeed={minimumWindSpeed}
+            minimumTemperature={minimumTemperature}
+            onChangeTemperatureUnit={this.changeTemperatureUnit}
+            onChangeSpeedUnit={this.changeSpeedUnit}
+            onChangeTemperature={this.changeminimumTemperature}
+            onChangeWindSpeed={this.changeminimumWindSpeed}
+          />
         )}
       </div>
     );
@@ -147,6 +167,27 @@ class Main extends Component {
   openSettingsMenu = () => {
     this.setState({ isSettingsMenuOpen: true });
   };
+
+  changeTemperatureUnit = temperatureUnit => {
+    this.setState({ temperatureUnit });
+  };
+
+  changeSpeedUnit = windSpeedUnit => {
+    this.setState({ windSpeedUnit });
+  };
+
+  changeminimumWindSpeed = minimumWindSpeed => {
+    this.setState({ minimumWindSpeed });
+  };
+
+  changeminimumTemperature = minimumTemperature => {
+    this.setState({ minimumTemperature });
+  };
+
+  updateSliderValue = sliderValue => {
+    this.setState({ sliderValue });
+  };
+
 }
 
 const styles = createStyles({

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -66,6 +66,7 @@ class Main extends Component {
   // This function queries the API, and if we receive a valid response we tidy
   // it up and store it in the state
   fetchWeatherFromAPI = async () => {
+    let currentWeather;
     const { lat, long } = this.state;
     // If coordinates have been set, query by GPS position. Otherwise use
     // automatic position (retrieved by IP)
@@ -78,7 +79,7 @@ class Main extends Component {
         if (!result.success) {
           console.error("Current API call failed", result.error);
         } else {
-          const currentWeather = {
+          currentWeather = {
             placeName: result.response.place.name,
             cityName: result.response.place.city,
             countryName: result.response.place.country,
@@ -86,10 +87,10 @@ class Main extends Component {
             tempC: result.response.ob.tempC,
             tempF: result.response.ob.tempF,
             humidity: result.response.ob.humidity,
-            windKTS: result.response.ob.windSpeedKTS,
-            windKPH: result.response.ob.windSpeedKPH,
-            windMPH: result.response.ob.windSpeedMPH,
-            windDirDeg: result.response.ob.windDirDEG,
+            windSpeedKTS: result.response.ob.windSpeedKTS,
+            windSpeedKPH: result.response.ob.windSpeedKPH,
+            windSpeedMPH: result.response.ob.windSpeedMPH,
+            windDirDEG: result.response.ob.windDirDEG,
             windDir: result.response.ob.windDir,
             windGustKTS: result.response.ob.windGustKTS,
             windGustKPH: result.response.ob.windGustKPH,
@@ -101,9 +102,9 @@ class Main extends Component {
             feelsLikeC: result.response.ob.feelsLikeC,
             feelsLikeF: result.response.ob.feelsLikeF,
             isDay: result.response.ob.isDay,
-            sunrise: result.response.ob.sunriseISO,
-            sunset: result.response.ob.sunsetISO,
-            skyCoverage: result.response.ob.sky
+            sunriseISO: result.response.ob.sunriseISO,
+            sunsetISO: result.response.ob.sunsetISO,
+            sky: result.response.ob.sky
           };
           this.setState({ currentWeather });
         }
@@ -118,6 +119,8 @@ class Main extends Component {
           this.setState({ isLoaded: false });
         } else {
           const forecastWeather = result.response[0].periods;
+          // Adding the currentWeather at the beginning of the forecast array
+          forecastWeather.unshift(currentWeather);
           this.setState({ forecastWeather, isLoaded: true });
         }
       });

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -31,6 +31,7 @@ class Main extends Component {
     windSpeedUnit: "KPH",
     minimumTemperature: 20,
     minimumWindSpeed: 15,
+    sliderValue: 0
   };
 
   render() {
@@ -54,6 +55,11 @@ class Main extends Component {
           onCloseSettings={this.closeSettingsMenu}
           onOpenSettings={this.openSettingsMenu}
         />
+        {isLoaded && (
+          <h1 style={{ display: this.checkIfCanFlyKite() ? "block" : "none" }}>
+            You can fly!
+          </h1>
+        )}
         {isSettingsMenuOpen === false ? (
           <GeneralData
             isLoaded={isLoaded}
@@ -61,6 +67,7 @@ class Main extends Component {
             forecastWeather={forecastWeather}
             temperatureUnit={temperatureUnit}
             windSpeedUnit={windSpeedUnit}
+            onChangeSliderValue={this.updateSliderValue}
           />
         ) : (
           <Settings
@@ -188,6 +195,31 @@ class Main extends Component {
     this.setState({ sliderValue });
   };
 
+  checkIfCanFlyKite = () => {
+    const {
+      minimumWindSpeed,
+      minimumTemperature,
+      temperatureUnit,
+      windSpeedUnit,
+      forecastWeather,
+      sliderValue
+    } = this.state;
+    const temperature =
+      temperatureUnit === "C"
+        ? forecastWeather[sliderValue].tempC
+        : forecastWeather[sliderValue].tempF;
+    const windSpeed =
+      windSpeedUnit === "KPH"
+        ? forecastWeather[sliderValue].windSpeedKPH
+        : windSpeedUnit === "MPH"
+        ? forecastWeather[sliderValue].windSpeedMPH
+        : forecastWeather[sliderValue].windSpeedKTS;
+
+    if (temperature >= minimumTemperature && windSpeed >= minimumWindSpeed) {
+      return true;
+    }
+    return false;
+  };
 }
 
 const styles = createStyles({

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -26,11 +26,25 @@ const minSpeedKTS = 0;
 class Settings extends Component {
   state = {
     checked: ["daytime"],
-    windSpeed: "15",
-    temperature: "20",
-    temperatureUnit: "C",
-    speedUnit: "KPH",
-    isOpen: false
+    windSpeed: "",
+    temperature: "",
+    temperatureUnit: "",
+    windSpeedUnit: ""
+  };
+
+  componentDidMount = () => {
+    const {
+      temperatureUnit,
+      windSpeedUnit,
+      minimumWindSpeed,
+      minimumTemperature
+    } = this.props;
+    this.setState({
+      temperatureUnit,
+      windSpeedUnit,
+      windSpeed: minimumWindSpeed,
+      temperature: minimumTemperature
+    });
   };
 
   // Handling array of switches
@@ -54,12 +68,14 @@ class Settings extends Component {
     const { windSpeed } = this.state;
     const newSpeed = parseInt(windSpeed) - 1;
     this.updateWindSpeedValue(newSpeed);
+    this.props.onChangeWindSpeed(newSpeed);
   };
 
   handleIncreaseWindSpeed = () => {
     const { windSpeed } = this.state;
     const newSpeed = parseInt(windSpeed) + 1;
     this.updateWindSpeedValue(newSpeed);
+    this.props.onChangeWindSpeed(newSpeed);
   };
 
   handleChangeWindSpeed = e => {
@@ -72,21 +88,24 @@ class Settings extends Component {
     // If user users letters or backspace/delete as first input, show 0 rather
     // than an empty textfield
     windSpeed = windSpeed === "" ? 0 : windSpeed;
-    const { speedUnit } = this.state;
-    switch (speedUnit) {
+    const { windSpeedUnit } = this.state;
+    switch (windSpeedUnit) {
       case "KPH":
         if (windSpeed <= maxSpeedKPH && windSpeed >= minSpeedKPH) {
           this.setState({ windSpeed });
+          this.props.onChangeWindSpeed(windSpeed);
         }
         break;
       case "MPH":
         if (windSpeed <= maxSpeedMPH && windSpeed >= minSpeedMPH) {
           this.setState({ windSpeed });
+          this.props.onChangeWindSpeed(windSpeed);
         }
         break;
       case "KTS":
         if (windSpeed <= maxSpeedKTS && windSpeed >= minSpeedKTS) {
           this.setState({ windSpeed });
+          this.props.onChangeWindSpeed(windSpeed);
         }
         break;
     }
@@ -96,12 +115,14 @@ class Settings extends Component {
     const { temperature } = this.state;
     const newTemperature = parseInt(temperature) - 1;
     this.updateTemperatureValue(newTemperature);
+    this.props.onChangeTemperature(newTemperature);
   };
 
   handleIncreaseTemperature = () => {
     const { temperature, temperatureUnit } = this.state;
     const newTemperature = parseInt(temperature) + 1;
     this.updateTemperatureValue(newTemperature);
+    this.props.onChangeTemperature(newTemperature);
   };
 
   handleChangeTemperature = e => {
@@ -119,11 +140,13 @@ class Settings extends Component {
         // to the minimum
         if (temperature <= maxTemperatureC && temperature >= minTemperatureC) {
           this.setState({ temperature });
+          this.props.onChangeTemperature(temperature);
         }
         break;
       case "F":
         if (temperature <= maxTemperatureF && temperature >= minTemperatureF) {
           this.setState({ temperature });
+          this.props.onChangeTemperature(temperature);
         }
         break;
     }
@@ -138,6 +161,7 @@ class Settings extends Component {
             ? Math.floor((this.state.temperature * 9) / 5 + 32)
             : Math.floor(((this.state.temperature - 32) * 5) / 9);
         this.updateTemperatureValue(convertedTemperature);
+        this.props.onChangeTemperatureUnit(this.state.temperatureUnit);
       });
     }
   };
@@ -152,11 +176,11 @@ class Settings extends Component {
     }
 
     if (value) {
-      const oldUnit = this.state.speedUnit;
-      this.setState({ speedUnit: value }, () => {
-        const { speedUnit, windSpeed } = this.state;
+      const oldUnit = this.state.windSpeedUnit;
+      this.setState({ windSpeedUnit: value }, () => {
+        const { windSpeedUnit, windSpeed } = this.state;
         let convertedWindSpeed;
-        if (oldUnit === "KPH" && speedUnit === "MPH")
+        if (oldUnit === "KPH" && windSpeedUnit === "MPH")
           convertedWindSpeed = mapRange(
             windSpeed,
             minSpeedKPH,
@@ -164,7 +188,7 @@ class Settings extends Component {
             minSpeedMPH,
             maxSpeedMPH
           );
-        if (oldUnit === "KPH" && speedUnit === "KTS")
+        if (oldUnit === "KPH" && windSpeedUnit === "KTS")
           convertedWindSpeed = mapRange(
             windSpeed,
             minSpeedKPH,
@@ -172,7 +196,7 @@ class Settings extends Component {
             minSpeedKTS,
             maxSpeedKTS
           );
-        if (oldUnit === "MPH" && speedUnit === "KPH")
+        if (oldUnit === "MPH" && windSpeedUnit === "KPH")
           convertedWindSpeed = mapRange(
             windSpeed,
             minSpeedMPH,
@@ -180,7 +204,7 @@ class Settings extends Component {
             minSpeedKPH,
             maxSpeedKPH
           );
-        if (oldUnit === "MPH" && speedUnit === "KTS")
+        if (oldUnit === "MPH" && windSpeedUnit === "KTS")
           convertedWindSpeed = mapRange(
             windSpeed,
             minSpeedMPH,
@@ -188,7 +212,7 @@ class Settings extends Component {
             minSpeedKTS,
             maxSpeedKTS
           );
-        if (oldUnit === "KTS" && speedUnit === "KPH")
+        if (oldUnit === "KTS" && windSpeedUnit === "KPH")
           convertedWindSpeed = mapRange(
             windSpeed,
             minSpeedKTS,
@@ -196,7 +220,7 @@ class Settings extends Component {
             minSpeedKPH,
             maxSpeedKPH
           );
-        if (oldUnit === "KTS" && speedUnit === "MPH")
+        if (oldUnit === "KTS" && windSpeedUnit === "MPH")
           convertedWindSpeed = mapRange(
             windSpeed,
             minSpeedKTS,
@@ -205,13 +229,22 @@ class Settings extends Component {
             maxSpeedMPH
           );
         this.updateWindSpeedValue(Math.round(convertedWindSpeed));
+        this.props.onChangeSpeedUnit(windSpeedUnit);
       });
     }
   };
 
   render() {
-    const { classes } = this.props;
-    const { temperatureUnit, speedUnit, isOpen } = this.state;
+    const {
+      classes,
+      isOpen,
+      temperatureUnit,
+      windSpeedUnit,
+      minimumWindSpeed,
+      minimumTemperature,
+      onChangeTemperature,
+      onChangeWindSpeed
+    } = this.props;
 
     return (
       <>
@@ -231,13 +264,13 @@ class Settings extends Component {
           </ListItem>
           <ListItem>
             <ListItemText
-              primary={`Minimum Wind Speed in ${speedUnit}`}
+              primary={`Minimum Wind Speed in ${windSpeedUnit}`}
               secondary={
-                this.state.speedUnit === "KPH"
-                  ? `Values between ${minSpeedKPH} ${speedUnit} and ${maxSpeedKPH} ${speedUnit}`
-                  : this.state.speedUnit === "MPH"
-                  ? `Values between ${minSpeedMPH} ${speedUnit} and ${maxSpeedMPH} ${speedUnit}`
-                  : `Values between ${minSpeedKTS} ${speedUnit} and ${maxSpeedKTS} ${speedUnit}`
+                this.state.windSpeedUnit === "KPH"
+                  ? `Values between ${minSpeedKPH} ${windSpeedUnit} and ${maxSpeedKPH} ${windSpeedUnit}`
+                  : this.state.windSpeedUnit === "MPH"
+                  ? `Values between ${minSpeedMPH} ${windSpeedUnit} and ${maxSpeedMPH} ${windSpeedUnit}`
+                  : `Values between ${minSpeedKTS} ${windSpeedUnit} and ${maxSpeedKTS} ${windSpeedUnit}`
               }
             />
             <ListItemSecondaryAction>
@@ -314,7 +347,7 @@ class Settings extends Component {
             />
             <ListItemSecondaryAction>
               <ToggleButtonGroup
-                value={this.state.speedUnit}
+                value={this.state.windSpeedUnit}
                 exclusive
                 onChange={this.handleChangeSpeedUnit}
               >


### PR DESCRIPTION
Quite a big PR.

In short:

- Connected Settings to Main: the parameters users edit from the settings page are now accessible from the main component.
- Changing units from the settings will reflect the changes in the main component.
- As soon as a user change a value in the settings, it will be stored
- Introduced method to check if "User can fly the kite", using the settings information and the data retrieved from the API: displaying a dummy `h1` to demonstrate/check it is actually working
- To simplify the code, instead of having 2 different states containing different objects (one for the current observation and another one for the forecast), I'm now pushing the current observation at the beginning of the forecast array. This way we only have to traverse one array.