### PR TITLE
GeneralData now displays weatherPrimary

### DIFF
--- a/src/components/GeneralData.jsx
+++ b/src/components/GeneralData.jsx
@@ -69,7 +69,7 @@ class GeneralData extends Component {
         <h1 className={classes.container}>
           {isLoaded &&
             isForecastAvailable &&
-            forecastWeather[sliderValue].weather}
+            forecastWeather[sliderValue].weatherPrimary}
         </h1>
       </div>
     );

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -17,7 +17,7 @@ const KEYS = `client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}`;
 const OPTIONS_CURRENT = `%format=json&filter=allstations&limit=1&${KEYS}`;
 const OPTIONS_FORECAST = `format=json&filter=1hr&limit=23&${KEYS}`;
 // Requesting only certain data to improve the speed of the response
-const DATA_TO_INCLUDE = `fields=periods.dateTimeISO,periods.tempC,periods.tempF,periods.windDirDEG,periods.windSpeedKTS,periods.windSpeedKPH,periods.windSpeedMPH,periods.weather,periods.isDay,periods.weatherPrimary`;
+const DATA_TO_INCLUDE = `fields=periods.dateTimeISO,periods.tempC,periods.tempF,periods.windDirDEG,periods.windSpeedKTS,periods.windSpeedKPH,periods.windSpeedMPH,periods.weatherPrimary,periods.isDay`;
 const OPTIONS_CALENDAR_FORECAST = `&to=+day?&format=json&filter=1hr&limit=24&${DATA_TO_INCLUDE}&${KEYS}`;
 class Main extends Component {
   state = {
@@ -209,7 +209,7 @@ class Main extends Component {
               windGustKPH: result.response.ob.windGustKPH,
               windGustMPH: result.response.ob.windGustMPH,
               weather: result.response.ob.weather,
-              weatherShort: result.response.ob.weatherShort,
+              weatherPrimary: result.response.ob.weatherPrimary,
               windchillC: result.response.ob.windchillC,
               windchillF: result.response.ob.windchillF,
               feelsLikeC: result.response.ob.feelsLikeC,

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -17,7 +17,7 @@ const KEYS = `client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}`;
 const OPTIONS_CURRENT = `%format=json&filter=allstations&limit=1&${KEYS}`;
 const OPTIONS_FORECAST = `format=json&filter=1hr&limit=23&${KEYS}`;
 // Requesting only certain data to improve the speed of the response
-const DATA_TO_INCLUDE = `fields=periods.dateTimeISO,periods.tempC,periods.tempF,periods.windDirDEG,periods.windSpeedKTS,periods.windSpeedKPH,periods.windSpeedMPH,periods.weather,periods.isDay`;
+const DATA_TO_INCLUDE = `fields=periods.dateTimeISO,periods.tempC,periods.tempF,periods.windDirDEG,periods.windSpeedKTS,periods.windSpeedKPH,periods.windSpeedMPH,periods.weather,periods.isDay,periods.weatherPrimary`;
 const OPTIONS_CALENDAR_FORECAST = `&to=+day?&format=json&filter=1hr&limit=24&${DATA_TO_INCLUDE}&${KEYS}`;
 class Main extends Component {
   state = {


### PR DESCRIPTION
## Summary

We are now displaying the `weatherPrimary`, which is a shorter version of `weather`. 
E.g. "Rain" rather than "Rain with an after taste of green tea, on a cold night in Stoke"

Done this for layout purposes. Much nicer is the length of the text is 1-3 words rather than a full sentence.